### PR TITLE
キャラ素質変化画面を変更

### DIFF
--- a/ERB/起床前メニュー関連処理/SHOP_ZP関連.ERB
+++ b/ERB/起床前メニュー関連処理/SHOP_ZP関連.ERB
@@ -552,6 +552,10 @@ ENDSELECT
 
 @ZP_素質変化(キャラ番号)
 #DIM キャラ番号
+#DIM CONST COST_TO_敏感 = 300
+#DIM CONST COST_TO_通常 = 100
+#DIM CONST COST_胸定数 = 20
+#DIM CONST COST_種族変化 = 200
 
 DRAWLINE
 PRINTL ZPを消費してキャラの素質を変化させることが出来ます。
@@ -584,7 +588,7 @@ ENDSELECT
 IF RESULT == 1
 	DRAWLINE
 	PRINTL ZPを消費してキャラに敏感系素質を付与することが出来ます。
-	PRINTL どの素質を敏感化しますか？
+	PRINTL どの部位を敏感化しますか？
 	DRAWLINE
 	FOR LOCAL:1 , 101, 106,
 		IF TALENT:キャラ番号:(LOCAL:1) > 0
@@ -593,11 +597,10 @@ IF RESULT == 1
 		ENDIF
 		IF TALENT:キャラ番号:(LOCAL:1) == -1
 			PRINTBUTTON @"[{LOCAL:1}]%TALENTNAME:(LOCAL:1)%:鈍感 > 通常", LOCAL:1
-			PRINTL 　　　必要ZP:100
 		ELSE
 			PRINTBUTTON @"[{LOCAL:1}]%TALENTNAME:(LOCAL:1)%:通常 > 敏感", LOCAL:1
-			PRINTL 　　　必要ZP:300
 		ENDIF
+		PRINTFORML 　　　必要ZP:{TALENT:キャラ番号:(LOCAL:1)==-1 ? COST_TO_通常 # COST_TO_敏感}
 	NEXT
 	PRINTBUTTON "[999]戻る", 999
 	$INPUT_LOOP2
@@ -613,29 +616,22 @@ IF RESULT == 1
 				GOTO INPUT_LOOP2
 			ENDIF
 			;ZP足りる？
-			IF TALENT:キャラ番号:(LOCAL:1) == -1 & FLAG:ZP所持量 < 100
-				PRINTW ZPが足りません
-				RESTART
-			ELSEIF TALENT:キャラ番号:(LOCAL:1) == 0 & FLAG:ZP所持量 < 300
+			IF (TALENT:キャラ番号:(LOCAL:1) == -1 & FLAG:ZP所持量 < COST_TO_通常) || (TALENT:キャラ番号:(LOCAL:1) == 0 & FLAG:ZP所持量 < COST_TO_敏感)
 				PRINTW ZPが足りません
 				RESTART
 			ENDIF
-			IF TALENT:キャラ番号:(LOCAL:1) == -1
-				PRINT 100
-			ELSEIF TALENT:キャラ番号:(LOCAL:1) == 0
-				PRINT 300
-			ENDIF
-			PRINTFORML ZPを支払い、%TALENTNAME:(LOCAL:1)%素質を上昇させますか？
+			PRINTFORML {TALENT:キャラ番号:(LOCAL:1)==-1 ? COST_TO_通常 # COST_TO_敏感}ZPを支払い、%TALENTNAME:(LOCAL:1)%を上昇させますか？
+			PRINTFORML （所持ZP：{FLAG:ZP所持量}）
 			PRINTBUTTONLC "[0]はい", 0
 			PRINTBUTTONLC "[1]いいえ", 1
 			INPUT
 			IF RESULT == 0
+				FLAG:ZP所持量 -= TALENT:キャラ番号:(LOCAL:1)==-1 ? COST_TO_通常 # COST_TO_敏感
+				PRINTFORM %TALENTNAME:(LOCAL:1)%が
 				IF TALENT:キャラ番号:(LOCAL:1) == -1
-					FLAG:ZP所持量 -= 100
-					PRINTFORMW %TALENTNAME:(LOCAL:1)%が鈍感から通常に変化しました。
+					PRINTFORMW 鈍感から通常に上昇しました。
 				ELSEIF TALENT:キャラ番号:(LOCAL:1) == 0
-					FLAG:ZP所持量 -= 300
-					PRINTFORMW %TALENTNAME:(LOCAL:1)%が通常から敏感に変化しました。
+					PRINTFORMW 通常から敏感に上昇しました。
 				ENDIF
 				TALENT:キャラ番号:(LOCAL:1) += 1
 			ENDIF
@@ -656,7 +652,7 @@ ELSEIF RESULT == 2
 			PRINTFORML [{LOCAL:1}]%GET_TALENTNAME(205, LOCAL:1)%（現在の大きさ）
 			RESETCOLOR
 		ELSE
-			PRINTBUTTON @"[{LOCAL:1}]%GET_TALENTNAME(205, LOCAL:1)%（{ABS(TALENT:キャラ番号:バストサイズ - LOCAL:1) * 20}）", LOCAL:1
+			PRINTBUTTON @"[{LOCAL:1}]%GET_TALENTNAME(205, LOCAL:1)%（{ABS(TALENT:キャラ番号:バストサイズ - LOCAL:1) * COST_胸定数}）", LOCAL:1
 			PRINTL
 		ENDIF
 	NEXT
@@ -672,17 +668,18 @@ ELSEIF RESULT == 2
 			GOTO INPUT_LOOP3
 		CASE -2 TO 3
 			;ZP足りる？
-			IF FLAG:ZP所持量 < ABS(TALENT:キャラ番号:バストサイズ - LOCAL:1) * 20
+			IF FLAG:ZP所持量 < ABS(TALENT:キャラ番号:バストサイズ - LOCAL:1) * COST_胸定数
 				PRINTW ZPが足りません
 			GOTO INPUT_LOOP3
 			ENDIF
-			PRINTFORM {ABS(TALENT:キャラ番号:バストサイズ - LOCAL:1) * 20}
+			PRINTFORM {ABS(TALENT:キャラ番号:バストサイズ - LOCAL:1) * COST_胸定数}
 			PRINTFORML ZPを支払い、バストサイズを変化させますか？
+			PRINTFORML （所持ZP：{FLAG:ZP所持量}）
 			PRINTBUTTONLC "[0]はい", 0
 			PRINTBUTTONLC "[1]いいえ", 1
 			INPUT
 			IF RESULT == 0
-				FLAG:ZP所持量 -= ABS(TALENT:キャラ番号:バストサイズ - LOCAL:1) * 20
+				FLAG:ZP所持量 -= ABS(TALENT:キャラ番号:バストサイズ - LOCAL:1) * COST_胸定数
 				PRINTFORMW %CALLNAME:キャラ番号%のバストサイズが%GET_TALENTNAME(205, TALENT:キャラ番号:バストサイズ)%から%GET_TALENTNAME(205, LOCAL:1)%に変化しました。
 				TALENT:キャラ番号:バストサイズ = LOCAL:1
 			ENDIF
@@ -703,7 +700,7 @@ ELSEIF RESULT == 3
 			PRINTL
 			RESETCOLOR
 		ELSE
-			PRINTBUTTON @"[{LOCAL:1}]%GET_TALENTNAME(200, LOCAL:1), 14, LEFT%必要ZP:200", LOCAL:1
+			PRINTBUTTON @"[{LOCAL:1}]%GET_TALENTNAME(200, LOCAL:1), 14, LEFT%必要ZP:{COST_種族変化}", LOCAL:1
 			PRINTL
 		ENDIF
 	NEXT
@@ -716,16 +713,17 @@ ELSEIF RESULT == 3
 			RESTART
 		CASE 1 TO 6
 			;ZP足りる？
-			IF FLAG:ZP所持量 < 200
+			IF FLAG:ZP所持量 < COST_種族変化
 				PRINTW ZPが足りません
 				GOTO INPUT_LOOP4
 			ENDIF
 			PRINTFORML 200ZPを支払い、種族を変化させますか？
+			PRINTFORML （所持ZP：{FLAG:ZP所持量}）
 			PRINTBUTTONLC "[0]はい", 0
 			PRINTBUTTONLC "[1]いいえ", 1
 			BINPUT
 			IF RESULT == 0
-				FLAG:ZP所持量 -= 200
+				FLAG:ZP所持量 -= COST_種族変化
 				PRINTFORMW %CALLNAME:キャラ番号%の種族が%GET_TALENTNAME(200, TALENT:キャラ番号:種族)%から%GET_TALENTNAME(200, LOCAL:1)%に変化しました。
 				CALL ZP_SHOP_種族特徴変換(キャラ番号, TALENT:キャラ番号:種族, LOCAL:1)
 				TALENT:キャラ番号:種族 = LOCAL:1


### PR DESCRIPTION
・他のZP消費タイミングと違ってキャラ素質変化画面ではZP消費タイミングで所持ZPが流れてしまって見えなくなってるので表示するように変更
・誤字修正
・マジックナンバー除去