### PR TITLE
性的能力表示画面で一部のフレーバー素質が表示されないことがある問題を修正

### DIFF
--- a/ERB/PRINT_STATE.ERB
+++ b/ERB/PRINT_STATE.ERB
@@ -710,11 +710,14 @@ IF フレーバー素質:ARG:素質表示設定 == 1
 		IF COUNT == 7
 			IF TALENT:ARG:性別 != 3
 				CONTINUE
-			ELSEIF OPTION変数:ふたなり玉設定 == 1
-				PRINTFORM %ERDNAME(フレーバー素質, COUNT), 10, LEFT%：%GET_フレーバー素質NAME(COUNT, 1), 12, LEFT%
-			ELSEIF OPTION変数:ふたなり玉設定 == 2
-				PRINTFORM %ERDNAME(フレーバー素質, COUNT), 10, LEFT%：%GET_フレーバー素質NAME(COUNT, 2), 12, LEFT%
 			ENDIF
+			PRINTL
+			SELECTCASE OPTION変数:ふたなり玉設定
+				CASE 0
+					PRINTFORM %ERDNAME(フレーバー素質, COUNT), 10, LEFT%：%GET_フレーバー素質NAME(COUNT, フレーバー素質:ARG:COUNT), 12, LEFT%
+				CASEELSE
+					PRINTFORM %ERDNAME(フレーバー素質, COUNT), 10, LEFT%：%GET_フレーバー素質NAME(COUNT, OPTION変数:ふたなり玉設定), 12, LEFT%
+			ENDSELECT
 			LOCAL += 1
 		ELSEIF フレーバー素質:ARG:COUNT
 			IF COUNT == 6
@@ -723,10 +726,10 @@ IF フレーバー素質:ARG:素質表示設定 == 1
 			ENDIF
 			PRINTFORM %ERDNAME(フレーバー素質, COUNT), 10, LEFT%：%GET_フレーバー素質NAME(COUNT, フレーバー素質:ARG:COUNT), 12, LEFT%
 			LOCAL += 1
-			IF LOCAL == 3
-				LOCAL = 0
-				PRINTL
-			ENDIF
+		ENDIF
+		IF LOCAL == 3
+			LOCAL = 0
+			PRINTL
 		ENDIF
 	NEXT
 	SIF LOCAL


### PR DESCRIPTION
OPTION変数:ふたなり玉設定==0のときにふたなり時_玉ありなしが表示されない問題を修正
(フレーバー素質じゃなくなるかもしれないけど)